### PR TITLE
Updated wildcard pattern to better handle double quote and plus symbols

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "solspace/craft3-commons",
   "description": "Solspace Commons Library for Craft CMS 3 plugins",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "library",
   "license": "MIT",
   "require": {

--- a/src/Helpers/ComparisonHelper.php
+++ b/src/Helpers/ComparisonHelper.php
@@ -13,7 +13,7 @@ class ComparisonHelper
     public static function stringContainsWildcardKeyword(string $pattern, string $string): bool
     {
         if (strpos($pattern, '"') !== false) {
-            return (stripos(strtolower($pattern), $string) !== false);
+            return (stripos($pattern, $string) !== false);
         } else {
             $pattern = '#\b' . self::wildcardToRegex($pattern) . '\b#i';
 
@@ -43,8 +43,7 @@ class ComparisonHelper
     private static function wildcardToRegex(string $wildcardPattern, string $delimiter = '/'): string
     {
         $converted = preg_quote($wildcardPattern, $delimiter);
-        $converted = str_replace('\*', '.*', $converted);
-        $converted = str_replace('\+', '\+?', $converted);
+        $converted = str_replace(['\*', '\+'], ['.*', '\+?'], $converted);
 
         return $converted;
     }

--- a/src/Helpers/ComparisonHelper.php
+++ b/src/Helpers/ComparisonHelper.php
@@ -12,9 +12,13 @@ class ComparisonHelper
      */
     public static function stringContainsWildcardKeyword(string $pattern, string $string): bool
     {
-        $pattern = '#\b' . self::wildcardToRegex($pattern) . '\b#i';
+        if (strpos($pattern, '"') !== false) {
+            return (stripos(strtolower($pattern), $string) !== false);
+        } else {
+            $pattern = '#\b' . self::wildcardToRegex($pattern) . '\b#i';
 
-        return (bool) preg_match($pattern, $string);
+            return (bool) preg_match($pattern, $string);
+        }
     }
 
     /**
@@ -40,6 +44,7 @@ class ComparisonHelper
     {
         $converted = preg_quote($wildcardPattern, $delimiter);
         $converted = str_replace('\*', '.*', $converted);
+        $converted = str_replace('\+', '\+?', $converted);
 
         return $converted;
     }

--- a/tests/Solspace/Commons/Helpers/ComparisonHelperTest.php
+++ b/tests/Solspace/Commons/Helpers/ComparisonHelperTest.php
@@ -26,6 +26,16 @@ class ComparisonHelperTest extends TestCase
             ['some@*.com', 'some@gmail.ru', false],
             ['[some@*.com', '[some@gmail.com', false],
             ['[some@*.com', 'some@gmail.com', false],
+            ['"Beautiful girls"', 'Beautiful', true],
+            ['"Beautiful girls"', 'girls', true],
+            ['"Beautiful girls"', 'Beautiful girls', true],
+            ['*@mail.me', 'some@mail.me', true],
+            ['some@*.me', 'some@mail.me', true],
+            ['some@mail.*', 'some@mail.me', true],
+            ['+974', '974', true],
+            ['+974', '+974', true],
+            ['b*brides', 'bestbrides', true],
+            ['*charming*', 'charmingdate', true],
         ];
     }
 


### PR DESCRIPTION
Freeform customer reported that enclosing phrases in double quotes or testing blocked keywords with +971 (as example) didn't work.

This PR improves handling of plus symbols (`+`) and moves the handling of double quotes (`"`) away from `preg_match`. During investigation and testing, I found that regex word boundary flags and double quotes don't seem to like each other.