### PR TITLE
Fix uninstall SQL error

### DIFF
--- a/src/Migrations/StreamlinedInstallMigration.php
+++ b/src/Migrations/StreamlinedInstallMigration.php
@@ -77,7 +77,7 @@ abstract class StreamlinedInstallMigration extends Migration
 
             foreach ($table->getForeignKeys() as $foreignKey) {
                 try {
-                    $this->dropForeignKey($foreignKey->getName(), $table->getDatabaseName());
+                    $this->dropForeignKeyIfExists($table->getDatabaseName(), $foreignKey->getColumn());
                 } catch (\Exception $e) {
                     \Craft::warning($e->getMessage());
                 }


### PR DESCRIPTION
Plugin uninstallers should not assume they know the name of a foreign key, or that it even actually exists, and instead call `dropForeignKeyIfExists()`, only passing the table name and column name(s) involved in the FK.

(Fixes a SQL error I specifically ran into when attempting to uninstall Freeform on [Europa](https://github.com/craftcms/europa-museum).)